### PR TITLE
ISSUE-4 feat(cart): wire remove button to cart.removeFromCart

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -7,10 +7,6 @@ function formatPrice(price: number): string {
   return price.toLocaleString('en-US', { style: 'currency', currency: 'USD' });
 }
 
-// TODO: Connect to cart.removeFromCart(item.id)
-function handleRemove(_itemId: string): void {
-  // no-op — waiting to be connected to the store
-}
 </script>
 
 <template>
@@ -72,17 +68,13 @@ function handleRemove(_itemId: string): void {
                       {{ formatPrice(item.price * item.quantity) }}
                     </div>
 
-                    <!--
-                      Remove button — rendered but click handler is a no-op.
-                      TODO: Connect to cart.removeFromCart(item.id)
-                    -->
                     <Button
                       label="✕"
                       severity="danger"
                       variant="text"
                       size="small"
                       aria-label="Remove item"
-                      @click="handleRemove(item.id)"
+                      @click="cart.removeFromCart(item.id)"
                     />
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
Wires the cart remove button's `@click` handler to `cart.removeFromCart(item.id)`, replacing the no-op wrapper function.

## Changes
- Remove `handleRemove` wrapper function and its TODO comment
- Change `@click="handleRemove(item.id)"` to `@click="cart.removeFromCart(item.id)"` directly

## Test Plan
- [x] All guardrails pass (unit-tests: 15 passed, 0 failed)

Closes #4

---
Agent: matt-blueghost/worker-24e7bd