### PR TITLE
ISSUE-3 feat(cart): enable quantity stepper and wire to store

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -52,18 +52,14 @@ function handleRemove(_itemId: string): void {
                 <div class="cart-item-controls">
                   <div class="cart-item-quantity">
                     <label class="qty-label">Qty</label>
-                    <!--
-                      Quantity stepper — rendered but not wired to the store.
-                      TODO: Connect to cart.updateQuantity(item.id, newQty)
-                    -->
                     <InputNumber
                       :model-value="item.quantity"
                       :min="1"
                       :max="99"
-                      :disabled="true"
                       show-buttons
                       button-layout="horizontal"
                       :input-style="{ width: '3rem', textAlign: 'center' }"
+                      @update:model-value="(val) => cart.updateQuantity(item.id, val)"
                     />
                   </div>
 


### PR DESCRIPTION
## Summary
Enables the quantity stepper on cart items by removing the `disabled` prop and wiring the `@update:modelValue` handler to `cart.updateQuantity()`.

## Changes
- Remove `:disabled="true"` from `InputNumber` in `pages/index.vue`
- Add `@update:model-value="(val) => cart.updateQuantity(item.id, val)"` handler
- Remove TODO comment — the wiring is now complete

## Test Plan
- [x] All 15 Vitest specs pass (`npm test`)
- Manual: change quantity on any item → subtotal and total update reactively
- Manual: quantity cannot go below 1 (store enforces `Math.max(1, ...)`)

Closes #3

---
Agent: matt-blueghost/worker-26284a