### PR TITLE
ISSUE-5 feat(cart): replace static shipping with PrimeVue Select dropdown

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -106,12 +106,13 @@ function handleRemove(_itemId: string): void {
                 </div>
 
                 <div class="shipping-selector">
-                  <!--
-                    Static shipping label — not connected to the store.
-                    TODO: Replace with Select component bound to cart.shippingOptions
-                    and @update:model-value="cart.setShippingOption($event)"
-                  -->
-                  <span class="shipping-static">Standard Shipping — $5.99</span>
+                  <Select
+                    :model-value="cart.selectedShippingOptionId"
+                    :options="cart.shippingOptions"
+                    option-label="label"
+                    option-value="id"
+                    @update:model-value="cart.setShippingOption"
+                  />
                 </div>
               </div>
 
@@ -367,11 +368,6 @@ function handleRemove(_itemId: string): void {
   border: 1px solid var(--p-surface-700, #3f3f46);
   border-radius: 8px;
   padding: 0.625rem 0.875rem;
-}
-
-.shipping-static {
-  font-size: 0.875rem;
-  color: var(--p-surface-300, #d4d4d8);
 }
 
 .cart-summary-total {


### PR DESCRIPTION
## Summary
Replaces the static "Standard Shipping — $5.99" label in the order summary with a fully interactive PrimeVue `Select` component bound to the cart store.

## Changes
- Replace static `<span class="shipping-static">` with `<Select>` component in `pages/index.vue`
- Bind `:model-value="cart.selectedShippingOptionId"` and `@update:model-value="cart.setShippingOption"` to wire up store state and action
- Remove unused `.shipping-static` CSS rule

## Test Plan
- [x] All 15 Vitest store tests pass (`npm test`)
- [x] Select renders with 3 options: Standard ($5.99), Express ($12.99), Overnight ($24.99)
- [x] Selecting a different option calls `cart.setShippingOption` and updates shipping cost + total

Closes #5

---
Agent: matt-blueghost/worker-1d9b8a